### PR TITLE
fix(db-operator/rbac): Add missing list and watch for deployments for custom resource monitoring

### DIFF
--- a/charts/db-operator/templates/controller/rbac.yaml
+++ b/charts/db-operator/templates/controller/rbac.yaml
@@ -81,6 +81,8 @@ rules:
   - get
   - create
   - update
+  - list
+  - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The operator needs this to monitor the custom resources.

Without these permissions the operator will fail to monitor custom resources and thus fail to update them.
