### PR TITLE
feat(db-operator): Make securityContext configurable to support PSA

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: db-operator
-version: 1.17.1
+version: 1.18.0
 # ---------------------------------------------------------------------------------
 # -- All supported k8s versions are in the test:
 # --  https://github.com/db-operator/charts/blob/main/.github/workflows/test.yaml

--- a/charts/db-operator/templates/controller/deployment.yaml
+++ b/charts/db-operator/templates/controller/deployment.yaml
@@ -29,13 +29,16 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "db-operator.serviceAccountName" . }}
       {{- end }}
-     {{- if .Values.security }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsUser: {{ .Values.security.runAsUser }}
-        fsGroup: {{ .Values.security.fsGroup }}
-     {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: operator
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ template "github_packages_image_version" . }}"
           ports:
           - containerPort: 60000

--- a/charts/db-operator/values.yaml
+++ b/charts/db-operator/values.yaml
@@ -5,19 +5,22 @@ image:
   logLevel: info
 # imagePullSecrets:
 #   - name: myRegistrySecret
+
 reconcileInterval: "60"
 # watchNamespace value is comma-separated list of namespace names. It's necessary to set "" to watch cluster wide.
 watchNamespace: ""
+
 # ------------------------------------------------------------
-# -- If set to true, db-operator will check if a Kubernetes
-# --   objects were changes before running database queries.
+# -- If set to true, db-operator will check if Kubernetes
+# -- objects were changed before running database queries.
 # -- It might reduce the amount of queries, because otherwise
-# --  db-operator will try to update database and users every
-# --  ${RECONCILE_INTERVAL} seconds.
+# -- db-operator will try to update databases and users every
+# -- ${RECONCILE_INTERVAL} seconds.
 # ------------------------------------------------------------
 # -- NOTE: Currently, it's only working with Database Users
 # ------------------------------------------------------------
 checkForChanges: false
+
 rbac:
   create: true
 serviceAccount:
@@ -53,9 +56,25 @@ webhook:
       # -- ClusterIssuer or Issuer
       # -----------------------------------------
       kind: Issuer
-security: {}
-#  runAsUser: 1000
-#  fsGroup: 1000
+
+# -- Configure the security context for the operator pods
+podSecurityContext:
+  # Default Pod Security Standard for restricted
+  # https://kubernetes.io/docs/concepts/security/pod-security-admission/
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+# runAsUser: 1000
+# fsGroup: 1000
+
+# -- Configure the security context for the operator container
+securityContext:
+  # Default Pod Security Standard for restricted
+  # https://kubernetes.io/docs/concepts/security/pod-security-admission/
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 resources: {}
 nodeSelector: {}


### PR DESCRIPTION
To comply with Pod Security Admission and to use the Pod Security Standard "restricted" for this we make it configurable with a sensible default.